### PR TITLE
Override methods

### DIFF
--- a/src/core/activity/activityChart/activityChartPanelModels/CVISIHistogramModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/CVISIHistogramModel.ts
@@ -23,7 +23,7 @@ export class CVISIHistogramModel extends SpikeTimesPlotModel {
     this.init();
   }
 
-  get params(): any[] {
+  override get params(): any[] {
     return this._params;
   }
 

--- a/src/core/activity/activityChart/activityChartPanelModels/analogSignalHistogramModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/analogSignalHistogramModel.ts
@@ -25,7 +25,7 @@ export class AnalogSignalHistogramModel extends ActivityChartPanelModel {
     this.init();
   }
 
-  get params(): any[] {
+  override get params(): any[] {
     return this._params;
   }
 

--- a/src/core/activity/activityChart/activityChartPanelModels/interSpikeIntervalHistogramModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/interSpikeIntervalHistogramModel.ts
@@ -28,7 +28,7 @@ export class InterSpikeIntervalHistogramModel extends SpikeTimesPlotModel {
     this.init();
   }
 
-  get params(): any[] {
+  override get params(): any[] {
     return this._params;
   }
 

--- a/src/core/activity/activityChart/activityChartPanelModels/spikeTimesHistogramModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/spikeTimesHistogramModel.ts
@@ -26,7 +26,7 @@ export class SpikeTimesHistogramModel extends SpikeTimesPlotModel {
     this.init();
   }
 
-  get params(): any[] {
+  override get params(): any[] {
     return this._params;
   }
 

--- a/src/core/network/network.ts
+++ b/src/core/network/network.ts
@@ -280,7 +280,7 @@ export class Network extends Config {
   /**
    * Copy network component.
    */
-  copy(item: any): any {
+  override copy(item: any): any {
     return JSON.parse(JSON.stringify(item));
   }
 

--- a/src/core/node/node.ts
+++ b/src/core/node/node.ts
@@ -433,7 +433,7 @@ export class Node extends Config {
    *
    * @return copied node object
    */
-  copy(item: any): any {
+  override copy(item: any): any {
     return JSON.parse(JSON.stringify(item));
   }
 

--- a/src/core/parameter/modelParameter.ts
+++ b/src/core/parameter/modelParameter.ts
@@ -11,7 +11,7 @@ export class ModelParameter extends Parameter {
   /**
    * Get options from model component.
    */
-  get options(): ModelParameter | undefined {
+  override get options(): ModelParameter | undefined {
     let model: Model;
     if (this.parent.name === 'Model') {
       model = this.parent as Model;

--- a/src/core/parameter/parameter.ts
+++ b/src/core/parameter/parameter.ts
@@ -210,7 +210,7 @@ export class Parameter extends Config {
   /**
    * Copy paramter component
    */
-  copy(): any {
+  override copy(): any {
     return new Parameter(this._parent, this);
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
+    "noImplicitOverride": true,
     "strictPropertyInitialization": false,
     "resolveJsonModule": true,
     "sourceMap": true,


### PR DESCRIPTION
This PR completes the `override` tagging procedure and sets it as the default compile option so that ESLint will hint such issues automatically in the future.