### PR TITLE
Restrict localNumThreads to integer

### DIFF
--- a/src/assets/config/SimulationKernel.json
+++ b/src/assets/config/SimulationKernel.json
@@ -2,6 +2,7 @@
   "autoRNGSeed": false,
   "params": [
     {
+      "format": "integer",
       "id": "localNumThreads",
       "input": "tickSlider",
       "label": "local number of threads",


### PR DESCRIPTION
Small addition introducing the strict integer format also for `localNumThreads`.