### PR TITLE
Add confirmation dialog for reset and improve texts

### DIFF
--- a/src/components/dialog/ModelsDialog.vue
+++ b/src/components/dialog/ModelsDialog.vue
@@ -60,10 +60,14 @@
 
     <v-dialog max-width="1024" v-else v-model="dialogState.open">
       <v-card>
-        <v-card-title
-          v-if="dialogState.data.models.length !== 0"
-          v-text="`Select models to ${dialogState.action}.`"
-        />
+        <v-card-title>
+          {{
+            dialogState.action.charAt(0).toUpperCase() +
+            dialogState.action.slice(1)
+          }}
+        </v-card-title>
+        <v-card-subtitle v-text="`Select projects to ${dialogState.action}`">
+        </v-card-subtitle>
 
         <v-card-text>
           <v-simple-table v-if="dialogState.data.models.length !== 0">

--- a/src/components/dialog/ModelsDialog.vue
+++ b/src/components/dialog/ModelsDialog.vue
@@ -1,8 +1,33 @@
 <template>
   <div class="ModelsDialog">
     <v-dialog
+      max-width="420"
+      v-if="dialogState.action === 'reload'"
+      v-model="dialogState.open"
+    >
+      <v-card>
+        <v-card-title v-text="'Are you sure to reload all models?'" />
+
+        <v-card-text>
+          The models will be reloaded from the database.
+          <br />
+          Any unsaved content in models will be deleted!
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="closeDialog" outlined small text v-text="'cancel'" />
+          <v-btn @click="reloadModels" outlined small>
+            <v-icon left v-text="'mdi-reload'" />
+            reload
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog
       max-width="480"
-      v-if="dialogState.action === 'reset'"
+      v-else-if="dialogState.action === 'reset'"
       v-model="dialogState.open"
     >
       <v-card>
@@ -148,10 +173,21 @@ export default Vue.extend({
     };
 
     /**
+     * Reload the models from the database.
+     */
+    const reloadModels = () => {
+      core.app.model.initModelList().then(() => {
+        core.app.model.view.redirect();
+      });
+      core.app.closeDialog();
+    };
+
+    /**
      * Reset model database.
      */
     const resetModels = () => {
       core.app.model.resetDatabase();
+      reloadModels();
     };
 
     return {
@@ -159,6 +195,7 @@ export default Vue.extend({
       deleteModels,
       dialogState,
       exportModels,
+      reloadModels,
       resetModels,
     };
   },

--- a/src/components/dialog/ModelsImportDialog.vue
+++ b/src/components/dialog/ModelsImportDialog.vue
@@ -2,6 +2,7 @@
   <div class="ModelsImportDialog">
     <v-card>
       <v-card-title v-text="'Import models'" />
+      <v-card-subtitle v-text="'Select source and file'" />
 
       <v-card-text>
         <v-row class="mb-1">
@@ -9,7 +10,7 @@
             <v-select
               :items="state.items"
               dense
-              label="Select a source"
+              label="Source"
               v-model="state.source"
             >
               <template slot="selection" slot-scope="data">
@@ -30,7 +31,7 @@
                   :items="state.trees"
                   @change="getFilesFromGithub"
                   dense
-                  label="Select element type"
+                  label="Element type"
                   prepend-icon="mdi-github"
                   v-model="state.selectedTree"
                 />
@@ -41,17 +42,18 @@
                   :items="state.files"
                   @change="getModelFromGithub"
                   dense
-                  label="Select file"
+                  label="File"
                   v-model="state.selectedFile"
                 />
               </v-col>
             </v-row>
             <v-file-input
-              @change="getModelFromFile"
+              @change="getModelsFromDrive"
               dense
-              label="File input"
+              label="File"
+              title="Click to select a file"
               truncate-length="100"
-              v-show="state.source === 'file'"
+              v-show="state.source === 'drive'"
             />
             <v-text-field
               @change="getModelFromUrl"
@@ -60,8 +62,9 @@
               dense
               flat
               full-width
-              label="Enter URL"
+              label="URL"
               prepend-icon="mdi-web"
+              title="Please enter the model's URL"
               v-show="state.source === 'url'"
             />
           </v-col>
@@ -72,7 +75,7 @@
             v-text="
               `${state.models.length} model${
                 state.models.length > 1 ? 's' : ''
-              } found. Select models to import.`
+              } found. Select models to import:`
             "
           />
 
@@ -152,8 +155,8 @@ export default Vue.extend({
       items: [
         {
           icon: 'mdi-paperclip',
-          text: 'file',
-          value: 'file',
+          text: 'drive',
+          value: 'drive',
         },
         {
           icon: 'mdi-github',
@@ -206,9 +209,9 @@ export default Vue.extend({
     };
 
     /**
-     * Get model from file.
+     * Get model from drive.
      */
-    const getModelFromFile = (file: any) => {
+    const getModelsFromDrive = (file: any) => {
       const fileReader = new FileReader();
       fileReader.readAsText(file);
       fileReader.addEventListener('load', (event: any) =>
@@ -217,7 +220,7 @@ export default Vue.extend({
     };
 
     /**
-     * Get trees from github.
+     * Get trees from GitHub.
      */
     const getTreesFromGithub = () => {
       state.selectedFile = {};
@@ -319,7 +322,7 @@ export default Vue.extend({
       closeDialog: () => core.app.closeDialog(),
       getFilesFromGithub,
       getModelFromGithub,
-      getModelFromFile,
+      getModelsFromDrive,
       getModelFromUrl,
       importModels,
       state,

--- a/src/components/dialog/ProjectsDialog.vue
+++ b/src/components/dialog/ProjectsDialog.vue
@@ -41,7 +41,7 @@
         />
 
         <v-card-text>
-          <v-simple-table v-if="dialogState.data.projects.length > 0">
+          <v-simple-table>
             <template #default>
               <thead>
                 <tr>
@@ -61,7 +61,10 @@
                   />
                 </tr>
               </thead>
-              <tbody :key="projectStore.state.numLoaded">
+              <tbody
+                :key="projectStore.state.numLoaded"
+                v-if="dialogState.data.projects.length > 0"
+              >
                 <tr
                   :key="index"
                   v-for="(project, index) in dialogState.data.projects"
@@ -133,6 +136,9 @@
                     </td>
                   </template>
                 </tr>
+              </tbody>
+              <tbody v-else>
+                No projects found
               </tbody>
             </template>
           </v-simple-table>

--- a/src/components/dialog/ProjectsDialog.vue
+++ b/src/components/dialog/ProjectsDialog.vue
@@ -60,10 +60,14 @@
 
     <v-dialog max-width="1024" v-else v-model="dialogState.open">
       <v-card>
-        <v-card-title
-          v-if="dialogState.data.projects.length !== 0"
-          v-text="`Select projects to ${dialogState.action}.`"
-        />
+        <v-card-title>
+          {{
+            dialogState.action.charAt(0).toUpperCase() +
+            dialogState.action.slice(1)
+          }}
+        </v-card-title>
+        <v-card-subtitle v-text="`Select projects to ${dialogState.action}`">
+        </v-card-subtitle>
 
         <v-card-text>
           <v-simple-table>

--- a/src/components/dialog/ProjectsDialog.vue
+++ b/src/components/dialog/ProjectsDialog.vue
@@ -1,8 +1,33 @@
 <template>
   <div class="ProjectsDialog">
     <v-dialog
+      max-width="420"
+      v-if="dialogState.action === 'reload'"
+      v-model="dialogState.open"
+    >
+      <v-card>
+        <v-card-title v-text="'Are you sure to reload all projects?'" />
+
+        <v-card-text>
+          The projects will be reloaded from the database.
+          <br />
+          Any unsaved content in projects will be deleted!
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="closeDialog" outlined small text v-text="'cancel'" />
+          <v-btn @click="reloadProjects" outlined small>
+            <v-icon left v-text="'mdi-reload'" />
+            reload
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog
       max-width="480"
-      v-if="dialogState.action === 'reset'"
+      v-else-if="dialogState.action === 'reset'"
       v-model="dialogState.open"
     >
       <v-card>
@@ -11,7 +36,7 @@
         <v-card-text>
           The database for projects will be deleted and then reset.
           <br />
-          Your modified projects will be lost!
+          Your modified projects will be lost! Please export them first!
         </v-card-text>
 
         <v-card-actions>
@@ -217,6 +242,16 @@ export default Vue.extend({
     };
 
     /**
+     * Reload the projects from the database.
+     */
+    const reloadProjects = () => {
+      core.app.project.initProjectList().then(() => {
+        core.app.project.view.redirect();
+      });
+      core.app.closeDialog();
+    };
+
+    /**
      * Reset project database.
      */
     const resetProjects = () => {
@@ -231,6 +266,7 @@ export default Vue.extend({
       deleteProjects,
       dialogState,
       exportProjects,
+      reloadProjects,
       resetProjects,
       projectStore: core.app.project,
     };

--- a/src/components/dialog/ProjectsImportDialog.vue
+++ b/src/components/dialog/ProjectsImportDialog.vue
@@ -2,6 +2,7 @@
   <div class="ProjectsImportDialog">
     <v-card>
       <v-card-title v-text="'Import projects'" />
+      <v-card-subtitle v-text="'Select source and file'" />
 
       <v-card-text>
         <v-row class="mb-1">
@@ -9,7 +10,7 @@
             <v-select
               :items="state.items"
               dense
-              label="Select a source"
+              label="Source"
               v-model="state.source"
             >
               <template slot="selection" slot-scope="data">
@@ -30,7 +31,7 @@
                   :items="state.trees"
                   @change="getFilesFromGithub"
                   dense
-                  label="Select path"
+                  label="Path"
                   prepend-icon="mdi-github"
                   v-model="state.selectedTree"
                 />
@@ -41,17 +42,18 @@
                   :items="state.files"
                   @change="getProjectsFromGithub"
                   dense
-                  label="Select file"
+                  label="File"
                   v-model="state.selectedFile"
                 />
               </v-col>
             </v-row>
             <v-file-input
-              @change="getProjectsFromFile"
+              @change="getProjectsFromDrive"
               dense
-              label="File input"
+              label="File"
+              title="Click to select a file"
               truncate-length="100"
-              v-show="state.source === 'file'"
+              v-show="state.source === 'drive'"
             />
             <v-text-field
               @change="getProjectsFromUrl"
@@ -60,8 +62,9 @@
               dense
               flat
               full-width
-              label="Enter URL"
+              label="URL"
               prepend-icon="mdi-web"
+              title="Please enter the project's URL"
               v-show="state.source === 'url'"
             />
           </v-col>
@@ -72,7 +75,7 @@
             v-text="
               `${state.projects.length} project${
                 state.projects.length > 1 ? 's' : ''
-              } found. Select projects to import.`
+              } found. Select projects to import:`
             "
           />
 
@@ -159,8 +162,8 @@ export default Vue.extend({
       items: [
         {
           icon: 'mdi-paperclip',
-          text: 'file',
-          value: 'file',
+          text: 'drive',
+          value: 'drive',
         },
         {
           icon: 'mdi-github',
@@ -213,9 +216,9 @@ export default Vue.extend({
     };
 
     /**
-     * Get projects from file.
+     * Get projects from drive.
      */
-    const getProjectsFromFile = (file: any) => {
+    const getProjectsFromDrive = (file: any) => {
       const fileReader = new FileReader();
       fileReader.readAsText(file);
       fileReader.addEventListener('load', (event: any) =>
@@ -298,7 +301,7 @@ export default Vue.extend({
       closeDialog: () => core.app.closeDialog(),
       getFilesFromGithub,
       getProjectsFromGithub,
-      getProjectsFromFile,
+      getProjectsFromDrive,
       getProjectsFromUrl,
       importProjects,
       state,

--- a/src/components/navigation/ModelNavList.vue
+++ b/src/components/navigation/ModelNavList.vue
@@ -185,7 +185,7 @@ export default Vue.extend({
           icon: 'mdi-reload',
           title: 'Reload models',
           onClick: () => {
-            modelStore.initModelList();
+            openDialog('reload');
           },
         },
         {
@@ -390,7 +390,10 @@ export default Vue.extend({
       // Reset states for model list.
       core.app.model.resetModelStates();
 
-      const models = action === 'reset' ? [] : core.app.model.state.models;
+      const models =
+        action === 'reset' || action === 'reload'
+          ? []
+          : core.app.model.state.models;
 
       // Open dialog for models.
       core.app.openDialog('models', action, { models });

--- a/src/components/navigation/ProjectNavList.vue
+++ b/src/components/navigation/ProjectNavList.vue
@@ -154,10 +154,8 @@ export default Vue.extend({
         {
           id: 'projectsReload',
           icon: 'mdi-reload',
-          title: 'Reload projects',
-          onClick: () => {
-            core.app.project.initProjectList();
-          },
+          title: 'Reload all projects from the database',
+          onClick: () => openDialog('reload'),
         },
         {
           id: 'projectsExport',
@@ -196,7 +194,9 @@ export default Vue.extend({
       // core.app.project.resetProjectStates();
 
       const projects =
-        action === 'reset' ? [] : core.app.project.state.projects;
+        action === 'reset' || action === 'reload'
+          ? []
+          : core.app.project.state.projects;
 
       // Open dialog for projects.
       core.app.openDialog('projects', action, { projects });

--- a/src/core/model/modelStore.ts
+++ b/src/core/model/modelStore.ts
@@ -88,7 +88,18 @@ export class ModelStore {
           (this._state.models = models.map(
             (model: any) => new Model(this._app, model)
           ))
-      );
+      )
+      // reload the view
+      .then(() => {
+        const currentRoute =
+          this._app.vueSetupContext.root.$router.currentRoute;
+        if (currentRoute.name === 'modelId') {
+          this.model =
+            this.getModel(currentRoute.params.id) ||
+            this.getModel(this.recentModelId);
+          this.view.redirect();
+        }
+      });
   }
 
   /**
@@ -210,6 +221,10 @@ export class ModelStore {
       this._state.models.find((model: Model) => model.id === modelId) ||
       new Model(this._app, { id: modelId, params: [] })
     );
+  }
+
+  get recentModelId(): string {
+    return this._state.models[0].id || undefined;
   }
 
   /**


### PR DESCRIPTION
This PR improves some of the descriptions and adds a confirmation dialogue for resetting the model list and the project list.

It also introduces a unified structure to the dialogues.
_Before_
> ![image](https://user-images.githubusercontent.com/53972736/196708884-5b9161da-a8e1-4f3e-8b12-d74d97e03bdf.png)
> ![image](https://user-images.githubusercontent.com/53972736/196708983-438f2eb7-601a-4aea-a639-689e3778fbf1.png)
> ![image](https://user-images.githubusercontent.com/53972736/196709042-7fd30919-c18c-49d5-87fd-fd9d68b99939.png)

_After_
> ![image](https://user-images.githubusercontent.com/53972736/196708329-081e0fdb-df92-4a9b-a554-0760247b79b1.png)
> ![image](https://user-images.githubusercontent.com/53972736/196708427-b5da20de-4da5-442a-8be6-1aa0ca914f6a.png)
> ![image](https://user-images.githubusercontent.com/53972736/196708483-d1534cac-4f10-4338-91f3-1e81514181da.png)

